### PR TITLE
Add Boolean/Constant to scopes

### DIFF
--- a/JSON.tmLanguage
+++ b/JSON.tmLanguage
@@ -149,7 +149,7 @@
 			<key>match</key>
 			<string>\b(?:true|false|null)\b</string>
 			<key>name</key>
-			<string>constant.language.json</string>
+			<string>constant.language.$0.json</string>
 		</dict>
 		<key>number</key>
 		<dict>


### PR DESCRIPTION
fixes #3
* #3

includes the constant in the scopeName via a replace capture
<img width="684" height="116" alt="image" src="https://github.com/user-attachments/assets/8ee2d3c0-e2f4-451d-b612-ab6e5489d28a" />

changes scopes `constant.language.json` to:
* `true`: `constant.language.true.json`
* `false`: `constant.language.false.json`
* `null`: `constant.language.null.json`

tested it in VSCode and TextMate 2.0

quite a few other grammars and themes already support this naming scheme
https://github.com/search?q=%22constant.language.true%22&type=code

before:
<img width="861" height="565" alt="image" src="https://github.com/user-attachments/assets/75d59dca-409e-41dc-8b16-78830718432a" />

after:
<img width="858" height="567" alt="image" src="https://github.com/user-attachments/assets/052581e3-b78b-43a0-aa46-59ae8bc20f32" />
